### PR TITLE
Fix ntfy notification formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Fix ntfy.sh notifications by sending JSON payload to avoid URL-encoded message contents.
+
 ## [1.8](https://github.com/kmwoley/restic-windows-backup/tree/1.8) (2025-02-20)
 [Full Changelog](https://github.com/kmwoley/restic-windows-backup/compare/1.7.1...1.8)
 

--- a/backup.ps1
+++ b/backup.ps1
@@ -370,10 +370,10 @@ function Send-Email {
             $payload = @{
                 title   = $subject
                 message = $body
-            }
+            } | ConvertTo-Json
 
             $temp_error_log = $ErrorLog + "_temp"
-            Invoke-RestMethod -Method Post -Uri $ResticNtfyUrl -Headers $headers -Body $payload 3>&1 2>> $temp_error_log | Out-File -Append $SuccessLog
+            Invoke-RestMethod -Method Post -Uri $ResticNtfyUrl -Headers $headers -Body $payload -ContentType "application/json" 3>&1 2>> $temp_error_log | Out-File -Append $SuccessLog
 
             if(-not $?) {
                 "[[Ntfy]] Sending notification completed with errors" | Tee-Object -Append $temp_error_log | Tee-Object -Append $SuccessLog | Write-Host


### PR DESCRIPTION
## Summary
- ensure ntfy.sh notifications send a JSON payload so messages aren't URL-encoded
- document change in changelog

## Testing
- `pwsh -NoProfile -Command "if (Get-Command Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue) { Invoke-ScriptAnalyzer -Path backup.ps1 } else { Write-Output 'Invoke-ScriptAnalyzer not installed' }"` *(fails: command not found: pwsh)*
- `apt-get update` *(fails: 403 - repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689be5514180832e9959092fc291aa28